### PR TITLE
Issue 41 max recursion depth

### DIFF
--- a/pdfreader/parsers/base.py
+++ b/pdfreader/parsers/base.py
@@ -9,7 +9,7 @@ class BasicTypesParser(object):
 
     exception_class = ParserException
     indirect_references_allowed = True
-    empty_names_allowed = False
+    empty_names_allowed = True
 
     def __init__(self, fileobj_or_buffer, offset=0):
         if isinstance(fileobj_or_buffer, Buffer):
@@ -285,13 +285,13 @@ class BasicTypesParser(object):
         'Name#with!^speci_#0_als#'
 
         >>> s = b'/'
-        >>> p = BasicTypesParser(s, 0)
-        >>> p.empty_names_allowed = True
-        >>> p.name()
+        >>> BasicTypesParser(s, 0).name()
         ''
 
         >>> s = b'/'
-        >>> BasicTypesParser(s, 0).name()
+        >>> p = BasicTypesParser(s, 0)
+        >>> p.empty_names_allowed = False
+        >>> p.name()
         Traceback (most recent call last):
         ...
         pdfreader.exceptions.ParserException: Empty /Name found

--- a/pdfreader/parsers/cmap.py
+++ b/pdfreader/parsers/cmap.py
@@ -14,7 +14,6 @@ class CMapParser(BasicTypesParser):
     """ Very poor implementation as we don't support PostScript language in full """
 
     exception_class = CMapParserException
-    empty_names_allowed = True
     indirect_references_allowed = False
 
     def object_or_token(self):

--- a/pdfreader/parsers/document.py
+++ b/pdfreader/parsers/document.py
@@ -11,7 +11,6 @@ class PDFParser(BasicTypesParser):
     PDF_HEADER = re.compile(b"^%PDF-(\d\.\d)", re.MULTILINE)
     IPS_HEADER = re.compile(b"^%IPS-Adobe-\d\.\d PDF-(\d\.\d)", re.MULTILINE)
 
-
     @staticmethod
     def is_empty_line(bline):
         """
@@ -396,10 +395,6 @@ class RegistryPDFParser(PDFParser):
         self.header = self.pdf_header()
         self.trailer = self.pdf_trailer()
         self.reset(self.header.offset)
-        self.brute_force_state = self.get_state()
-
-    def set_brute_force_offset(self, offset):
-
         self.brute_force_state = self.get_state()
 
     def on_parsed_indirect_object(self, obj):


### PR DESCRIPTION
Fixes #41 
There were 2 reasons for infinite recursion:
1. Empty name tokens led to ParserErrors in the 1st file
2. A stream `/Length` in the second file is defined as a reference to indirect object following the stream. The reference is not listed on xref.

Solutions:
1. Allow empty names
2. Brute-force objects lookup improved