### PR TITLE
changed logger to use module name, downstream changes to log statements

### DIFF
--- a/pdfreader/codecs/decoder.py
+++ b/pdfreader/codecs/decoder.py
@@ -1,5 +1,6 @@
 import codecs
 import logging
+log = logging.getLogger(__name__)
 import pkg_resources
 
 from io import BytesIO
@@ -37,7 +38,7 @@ def _guess_encoding_by_font_name(name):
     encoding = None
     if name == 'Symbol':
         # ToDo: It must be cp1038 decoder, which is missing now. it's one of predefined PostScript fonts
-        logging.warning("Symbol (aka cp1038) codec not implemented")
+        log.warning("Symbol (aka cp1038) codec not implemented")
         encoding = 'Identity-H'
     elif name in ('Times-Roman', 'Helvetica', 'Courier', 'Symbol', 'Times-Bold', 'Helvetica-Bold', 'Courier-Bold',
                   'Times-Italic', 'Helvetica-Qblique', 'Courier-Oblique', 'Times-BoldItalic', 'Helvetica-BoldOblique',
@@ -159,7 +160,7 @@ class EncodingDecoder(BaseDecoder):
             try:
                 codec = codecs.lookup(self.encoding)
             except LookupError:
-                logging.warning("Unsupported encoding {}. Using default {}".format(self.encoding, DEFAULT_ENCODING))
+                log.warning("Unsupported encoding {}. Using default {}".format(self.encoding, DEFAULT_ENCODING))
                 codec = codecs.lookup(DEFAULT_ENCODING)
         elif isinstance(self.encoding, DictBasedObject):
             # Encoding object - See PDF spec PDF32000_2008.pdf p.255 sec 9.6.1
@@ -184,7 +185,7 @@ def Decoder(font):
     else:
         # Encoding can be defined as a part of PostScript Font program, which is not supported.
         # Anyway, let's try do decode somehow.
-        logging.warning("Can't build Decoder for font {}. Trying to use default.".format(font))
+        log.warning("Can't build Decoder for font {}. Trying to use default.".format(font))
         decoder = default_decoder
     return decoder
 

--- a/pdfreader/codecs/differences.py
+++ b/pdfreader/codecs/differences.py
@@ -1,4 +1,5 @@
 import logging
+log = logging.getLogger(__name__)
 
 from . import winansi, pdfdoc, macroman, standard
 from .codec import Codec
@@ -46,7 +47,7 @@ def DifferencesCodec(encoding_obj):
         # There are usecases when BaseEncoding is None, Differences exists and all this makes sense as
         # content contains Differences characters only.
         # Anyway we have to try decode.
-        logging.warning("Unknown BaseEncoding {}. Trying {}".format(encoding_obj.BaseEncoding, implicit_base_encoding))
+        log.warning("Unknown BaseEncoding {}. Trying {}".format(encoding_obj.BaseEncoding, implicit_base_encoding))
         codec = base_encodings_map[implicit_base_encoding]
 
     dt = dict(codec.decode_table)

--- a/pdfreader/document.py
+++ b/pdfreader/document.py
@@ -1,4 +1,5 @@
 import logging
+log = logging.getLogger(__name__)
 
 from .registry import Registry
 from .parsers import RegistryPDFParser
@@ -67,7 +68,7 @@ class PDFDocument(object):
         :param visited: Shouldn't be used. Internal param containing already resolved objects
                         to not fall into infinite loops
         """
-        logging.debug("Buliding {}".format(obj))
+        log.debug("Buliding {}".format(obj))
         if visited is None:
             visited = []
 
@@ -91,7 +92,7 @@ class PDFDocument(object):
             obj = obj_factory(self, obj)
         elif isinstance(obj, IndirectObject):
             # normally this shouldn't happen, but ponentially we can build it
-            logging.warning("Attempt to build an indirect object. Possibly a bug.")
+            log.warning("Attempt to build an indirect object. Possibly a bug.")
             obj = self.build(obj.val, visited, lazy)
 
         if on_return:

--- a/pdfreader/filters/ascii85.py
+++ b/pdfreader/filters/ascii85.py
@@ -1,4 +1,5 @@
 import logging
+log = logging.getLogger(__name__)
 
 from base64 import  a85decode
 
@@ -27,7 +28,7 @@ def decode(data, *_):
         else:
             raise ValueError("EOD ~> expected")
     except (TypeError, ValueError):
-        logging.exception("Skipping broken stream")
+        log.exception("Skipping broken stream")
         res = b''
     return res
 

--- a/pdfreader/filters/asciihex.py
+++ b/pdfreader/filters/asciihex.py
@@ -1,4 +1,5 @@
 import logging
+log = logging.getLogger(__name__)
 
 from ..constants import WHITESPACES, DEFAULT_ENCODING
 
@@ -44,7 +45,7 @@ def decode(data, *_):
             res += bytes.fromhex(buffer.decode(DEFAULT_ENCODING))
     except ValueError:
         # invalid characters on stream
-        logging.exception("Skipping broken stream")
+        log.exception("Skipping broken stream")
     return res
 
 

--- a/pdfreader/filters/flate.py
+++ b/pdfreader/filters/flate.py
@@ -1,4 +1,6 @@
-import logging, zlib
+import zlib
+import logging
+log = logging.getLogger(__name__)
 
 from .predictors import _remove_predictors
 
@@ -20,7 +22,7 @@ def decode(data, params):
         data = zlib.decompress(data)
         data = _remove_predictors(data, params.get("Predictor"), params.get("Columns"))
     except zlib.error:
-        logging.exception("Skipping broken stream")
+        log.exception("Skipping broken stream")
         data = b''
     return data
 

--- a/pdfreader/filters/runlength.py
+++ b/pdfreader/filters/runlength.py
@@ -1,4 +1,5 @@
 import logging
+log = logging.getLogger(__name__)
 
 
 filter_names = ('RunLengthDecode', 'RL')
@@ -43,7 +44,7 @@ def decode(data, *_):
                 state = 'need_length'
 
     if state != 'done':
-        logging.error("Skipping broken stream")
+        log.error("Skipping broken stream")
         res = b''
 
     return res

--- a/pdfreader/parsers/cmap.py
+++ b/pdfreader/parsers/cmap.py
@@ -1,4 +1,5 @@
 import logging
+log = logging.getLogger(__name__)
 
 from ..exceptions import ParserException
 from ..types.native import Name, Token, Integer, HexString, Array
@@ -165,7 +166,7 @@ class CMapParser(BasicTypesParser):
             cmapname = self.cmap_name()
         except ParserException:
             # see cmap-sample-4.txt (page 9 samples/tyler-or-inline-image.pdf) - missing /CMapName
-            logging.debug("Missing /CMapName")
+            log.debug("Missing /CMapName")
             cmapname = None
             self.set_state(state)
 

--- a/pdfreader/parsers/content.py
+++ b/pdfreader/parsers/content.py
@@ -1,4 +1,5 @@
 import logging
+log = logging.getLogger(__name__)
 
 from .base import BasicTypesParser
 from ..types.content import Operator, InlineImage
@@ -25,7 +26,7 @@ class ContentParser(BasicTypesParser):
             obj = self.object()
             if isinstance(obj, InlineImage):
                 if operands:
-                    logging.warning("Skipping heading operands for inline image: {}".format(operands))
+                    log.warning("Skipping heading operands for inline image: {}".format(operands))
                 operands = []
                 yield obj
             elif self.is_operator(obj):
@@ -36,7 +37,7 @@ class ContentParser(BasicTypesParser):
                 operands.append(obj)
             self.maybe_spaces_or_comments()
         if operands:
-            logging.warning("Skipping trailing operands at the end of stream: {}".format(operands))
+            log.warning("Skipping trailing operands at the end of stream: {}".format(operands))
 
     @staticmethod
     def is_operator(obj):

--- a/pdfreader/pillow.py
+++ b/pdfreader/pillow.py
@@ -1,4 +1,5 @@
 import logging
+log = logging.getLogger(__name__)
 
 from io import BytesIO
 
@@ -75,7 +76,7 @@ class PILImageMixin(object):
                     img.putpalette(lookup, self.get_pil_colorspace(base_cs))
                     img.frombytes(self.filtered)
                 else:
-                    logging.debug("Unexpected colorspace: {}".format(my_cs))
+                    log.debug("Unexpected colorspace: {}".format(my_cs))
                     img = Image.frombytes(self.get_pil_colorspace(base_cs), size, self.data)
             else:
                 cs = self.get_pil_colorspace(self.ColorSpace)

--- a/pdfreader/registry.py
+++ b/pdfreader/registry.py
@@ -1,4 +1,5 @@
 import logging
+log = logging.getLogger(__name__)
 
 from .parsers import ObjStmParser
 from .types import Stream
@@ -23,11 +24,11 @@ class Registry(object):
             key = obj.num, obj.gen
             self.known_indirect_objects[key] = obj.val
             self.indirect_object_offsets[key] = (b_offset, e_offset)
-            logging.debug("Indirect object registered: {key} -> {val}".format(key=key, val=obj.val))
+            log.debug("Indirect object registered: {key} -> {val}".format(key=key, val=obj.val))
 
             if isinstance(obj.val, Stream):
                 if obj.val.get("Type") == "ObjStm":
-                    logging.debug("Registering ObjStm {}".format(key))
+                    log.debug("Registering ObjStm {}".format(key))
                     self.register_object_stream(obj.val)
 
     def get(self, n, gen):
@@ -43,5 +44,5 @@ class Registry(object):
         for obj in parser.objects(objstm["First"], objstm["N"]):
             # generation is always 0 for compressed objects
             self.register(obj)
-            logging.debug("Compressed object registered {} {}".format(obj.num, obj.gen))
+            log.debug("Compressed object registered {} {}".format(obj.num, obj.gen))
 

--- a/pdfreader/types/native.py
+++ b/pdfreader/types/native.py
@@ -1,4 +1,5 @@
 import logging
+log = logging.getLogger(__name__)
 
 from decimal import Decimal
 
@@ -55,7 +56,7 @@ def apply_filter_multi(filters, binary, params):
             binary = apply_filter(fname, binary, params)
             filters_applied.append(fname)
         except NotImplementedError:
-            logging.exception("Partially decoded. Filters applied: {}".format(filters_applied))
+            log.exception("Partially decoded. Filters applied: {}".format(filters_applied))
             raise
 
     return binary
@@ -81,7 +82,7 @@ class Stream(object):
             raise KeyError("Missing stream length")
 
         if info_dict["Length"] != len(binary_stream):
-            logging.warning("Inconsistent stream: defined length {}, real length {}"
+            log.warning("Inconsistent stream: defined length {}, real length {}"
                             .format(info_dict["Length"], len(binary_stream)))
 
         self.dictionary = info_dict

--- a/pdfreader/types/xref.py
+++ b/pdfreader/types/xref.py
@@ -1,4 +1,5 @@
 import logging
+log = logging.getLogger(__name__)
 
 from collections import OrderedDict
 
@@ -17,7 +18,7 @@ class BaseXrefEntry(object):
         assert isinstance(generation, int) and generation >= 0
 
         if generation > MAX_GEN:
-            logging.warning("Incorrect generation {} for entry {}".format(generation, number))
+            log.warning("Incorrect generation {} for entry {}".format(generation, number))
 
         self.number = number
         self.generation = generation
@@ -155,7 +156,7 @@ class XRef(object):
             else:
                 # PDF 1.5-1.7 defines any other reference types as references to null objects.
                 # so we just skip those
-                logging.debug("Undefined xref col type (index 0): {}".format(cols))
+                log.debug("Undefined xref col type (index 0): {}".format(cols))
 
             if entry is not None:
                 self.add_entry(entry)

--- a/pdfreader/viewer/graphicsstate.py
+++ b/pdfreader/viewer/graphicsstate.py
@@ -1,4 +1,5 @@
 import logging
+log = logging.getLogger(__name__)
 
 from typing import List
 from copy import deepcopy
@@ -81,7 +82,7 @@ class GraphicsStateStack(List[GraphicsState]):
         if self:
             self.pop()
         else:
-            logging.warning("Can't reset empty state")
+            log.warning("Can't reset empty state")
 
     def _get_state(self):
         if not self:

--- a/pdfreader/viewer/pdfviewer.py
+++ b/pdfreader/viewer/pdfviewer.py
@@ -1,4 +1,5 @@
 import logging
+log = logging.getLogger(__name__)
 
 from itertools import islice
 
@@ -83,7 +84,7 @@ class ContextualViewer(object):
         elif isinstance(obj, InlineImage):
             name = "{stage}_inline_image".format(stage=stage)
         else:
-            logging.warning("Unexpected content object type {}".format(type(obj)))
+            log.warning("Unexpected content object type {}".format(type(obj)))
         return name
 
     def get_resources(self):
@@ -179,7 +180,7 @@ class ContextualViewer(object):
         if state:
             self.gss.state.update(GraphicsState(**state))
         else:
-            logging.warning("Graphics state {} was not found on resources".format(name))
+            log.warning("Graphics state {} was not found on resources".format(name))
 
     # *Do* operator state manipulations
     def before_Do(self, op):

--- a/pdfreader/viewer/resources.py
+++ b/pdfreader/viewer/resources.py
@@ -1,4 +1,5 @@
 import logging
+log = logging.getLogger(__name__)
 
 from ..types.native import Dictionary, Array, Name
 from ..types.objects import Page
@@ -57,7 +58,7 @@ class Resources(object):
                         else:
                             kwargs[entry].update(pname)
                 else:
-                    logging.warning("Skipping unexpected resources entry type: {} -> {}"
+                    log.warning("Skipping unexpected resources entry type: {} -> {}"
                                     .format(entry, type(dict_or_array)))
 
         return Resources(**kwargs)

--- a/pdfreader/viewer/simple.py
+++ b/pdfreader/viewer/simple.py
@@ -1,4 +1,5 @@
 import logging
+log = logging.getLogger(__name__)
 from base64 import b85encode
 
 from pdfreader.constants import DEFAULT_ENCODING
@@ -54,7 +55,7 @@ def object_to_string(obj):
         entries += " /Filter [{}]".format(str_filters)
         val = "\nBI\n{entries}\nID\n{content}\nEI".format(entries=entries, content=content.decode('ascii'))
     elif isinstance(obj, bytes):
-        logging.warning("Binary data. Using default encoding. Possibly arg of unsupported operator: {}"
+        log.warning("Binary data. Using default encoding. Possibly arg of unsupported operator: {}"
                         .format(repr(bytes)))
         val = obj.decode(DEFAULT_ENCODING, 'replace')
     else:


### PR DESCRIPTION
I've modified the logging to not connect to the parent logger coming from the module importing pdfreader. Each file has been modified to add `log = logging.getLogger(__name__)` and the logging.<level> statements have been updated to log.<level> for correct operation.

This resolves issue #93.

If I need to change the pull request, let me know. I'm a noob.