### PR TITLE
Fix pillow.py

### DIFF
--- a/pdfreader/pillow.py
+++ b/pdfreader/pillow.py
@@ -68,7 +68,7 @@ class PILImageMixin(object):
             # FlateDecode and others
             if isinstance(self.ColorSpace, Array):
                 cs = self.ColorSpace
-                my_cs, base_cs, hival, lookup = cs[0], cs[1], cs[2], cs[3].filtered
+                my_cs, base_cs, hival, lookup = cs[0], cs[1], cs[2], cs[3].to_bytes()
 
                 if my_cs == 'Indexed':
                     img = Image.new("P", size)


### PR DESCRIPTION
pillow.py calls `cs[3].filtered` when `cs[3]` is of type `HexString`, being the palette data for an indexed colorspace. But `HexString` does not have a `filtered` attribute. Changed it to `.to_bytes()` to convert the strings to bytes, which is what Pillow expects for palette data.