### PR TITLE
ISSUE-109: work around mismatching predictors and broken image streams

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,8 @@
 pdfreader 0.1.13dev
 ---------------------------
+- issue #109 - work around unexpected predictors and corrupted images
+- Bump pycryptodome from 3.9.9 to 3.19.1
+- issue #113 - get rid of `pkg_resources`
 - issue #93 - logging issue
 - issue #99 - color space lookups issue fixed
 

--- a/pdfreader/codecs/decoder.py
+++ b/pdfreader/codecs/decoder.py
@@ -21,7 +21,7 @@ class PredefinedCmaps(object):
     def _load(name):
         from ..parsers import CMapParser
         fname = predefined_cmap_names[name]
-        with resources.open_binary('pdfreader.codecs', 'cmaps/{}'.format(fname)) as fd:
+        with resources.files('pdfreader.codecs').joinpath('cmaps/{}'.format(fname)).open('rb') as fd:
             return CMapParser(fd).cmap()
 
     @staticmethod
@@ -82,13 +82,13 @@ class BaseDecoder(object):
 class CMAPDecoder(BaseDecoder):
     """
 
+    >>> import pdfreader.codecs.decoder
     >>> font = dict(Encoding=Name("Identity-V"))
     >>> decoder = CMAPDecoder(font)
     >>> decoder.decode_hexstring('004100420043003100320033')
     'ABC123'
 
     >>> from unittest.mock import Mock, patch
-    >>> import pdfreader.codecs.decoder
     >>> cmap = Mock()
     >>> cmap.bf_ranges = {'0001': 'A', '0002': 'B', '0003': 'C', '0004': '1',  '0005': '2',  '0006': '3'}
     >>> with patch.object(pdfreader.codecs.decoder, '_get_cmap_encoding', return_value=(cmap, None)) as _:

--- a/pdfreader/filters/predictors.py
+++ b/pdfreader/filters/predictors.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger(__name__)
+
 def _remove_predictors(data, predictor=None, columns=None):
     """ Remove LZW/Flate predictors
     1 - No prediction
@@ -20,9 +23,11 @@ def _remove_predictors(data, predictor=None, columns=None):
         row_size = columns + 1
         res = b''
         for i in range(0, len(data), row_size):
-            if data[0] + 10 != predictor:
-                raise ValueError("Unexpected predictor {}".format(data[0]))
+            if data[i] + 10 != predictor:
+                log.debug("Unexpected predictor {} in row {}. Expected value {}, columns {}"
+                          .format(data[0] + 10, i, predictor, columns))
             res += data[i + 1:i + row_size]  # skip leading predictor byte
+
     else:
         raise ValueError("Unknown predictor type {}".format(predictor))
     return res


### PR DESCRIPTION
work around mismatching predictors and broken image streams 

A document in #109 has embedded images which are not displayed in Actobat, but there are objects for them. The images have too short data streams (comparatively to the image `Size` declared`) and PNG predictors on some data rows different from `Predictor` on the image.

1. Image parser doesn't blow up on mismatching predictors
2. It makes an attempt to recover broken image streams naively - truncate data or append zeros.