### PR TITLE
ISSUE-106: use Unicode replace character when codes are out of Unicode range

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,10 +1,11 @@
 pdfreader 0.1.13dev
 ---------------------------
-- issue #109 - work around unexpected predictors and corrupted images
-- Bump pycryptodome from 3.9.9 to 3.19.1
-- issue #113 - get rid of `pkg_resources`
-- issue #93 - logging issue
-- issue #99 - color space lookups issue fixed
+ - issue #106 - use Unicode replace character when codes are out of Unicode range
+ - issue #109 - work around unexpected predictors and corrupted images
+ - Bump pycryptodome from 3.9.9 to 3.19.1
+ - issue #113 - get rid of `pkg_resources`
+ - issue #93 - logging issue
+ - issue #99 - color space lookups issue fixed
 
 pdfreader 0.1.12
 ---------------------------

--- a/pdfreader/types/cmap.py
+++ b/pdfreader/types/cmap.py
@@ -79,10 +79,23 @@ class MapRange(Range):
         Traceback (most recent call last):
         ...
         KeyError: '05'
+        >>> r = MapRange("00", "04", 0x10FFFF)
+        >>> r["00"]
+        '\U0010ffff'
+        >>> r["01"], r["02"], r["03"], r["04"]
+        ('�', '�', '�', '�')
         """
         if item not in self:
             raise KeyError(item)
-        return chr(self.map_to_start + (HexString(item).as_int - self.int_begin))
+
+        code = self.map_to_start + (HexString(item).as_int - self.int_begin)
+        if 0 <= code <= 0x10FFFF:
+            # valid unicode range
+            val = chr(code)
+        else:
+            val = chr(0xFFFD) # unicode REPLACEMENT CHARACTER
+
+        return val
 
     def get(self, item, default=None):
         """

--- a/pdfreader/viewer/simple.py
+++ b/pdfreader/viewer/simple.py
@@ -55,8 +55,7 @@ def object_to_string(obj):
         entries += " /Filter [{}]".format(str_filters)
         val = "\nBI\n{entries}\nID\n{content}\nEI".format(entries=entries, content=content.decode('ascii'))
     elif isinstance(obj, bytes):
-        log.warning("Binary data. Using default encoding. Possibly arg of unsupported operator: {}"
-                        .format(repr(bytes)))
+        log.debug("Binary data. Using default encoding. Possibly arg of unsupported operator: {}".format(repr(bytes)))
         val = obj.decode(DEFAULT_ENCODING, 'replace')
     else:
         raise ValueError("Unexpected object: {}. Possibly a bug.".format(obj))


### PR DESCRIPTION
Fixes #106 - the problem was with the unicode characters out of Unicode range. We use the replacement character for these cases now.