### PR TITLE
don't raise error on unsupported stream filters

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 pdfreader 0.1.15dev
 ---------------------------
+- don't raise error on unsupported stream filters, return raw unfiltered data instead
 - issue #101 - DCT stream data encoding support
 - issue #130 - PDF date regular expression fixed
 - issue #62 - work around unbalanced BT/ET

--- a/pdfreader/filters/ccittfax.py
+++ b/pdfreader/filters/ccittfax.py
@@ -12,6 +12,8 @@
 
 
 import array
+import logging
+log = logging.getLogger(__name__)
 
 filter_names = ('CCITTFaxDecode', 'CCF')
 
@@ -545,7 +547,8 @@ def ccittfaxdecode(data, params):
     if K == -1:
         parser = CCITTFaxDecoder(cols, bytealign=bytealign, reversed=reversed)
     else:
-        raise ValueError(K)
+        log.warning("CCITT 1d and 2d decoders are not implemented. Returning raw unfiltered data.")
+        return data
     parser.feedbytes(data)
     return parser.close()
 

--- a/pdfreader/filters/jbig2.py
+++ b/pdfreader/filters/jbig2.py
@@ -1,5 +1,9 @@
+import logging
+log = logging.getLogger(__name__)
+
 filter_names = ('JBIG2Decode',)
 
 
 def decode(binary, params):
-    raise NotImplementedError('JBIG2Decode')
+    log.warning("JBIG2 decoder is not implemented. It returns raw unfiltered data.")
+    return binary

--- a/pdfreader/filters/jpx.py
+++ b/pdfreader/filters/jpx.py
@@ -1,5 +1,9 @@
+import logging
+log = logging.getLogger(__name__)
+
 filter_names = ('JPXDecode',)
 
 
 def decode(binary, params):
-    raise NotImplementedError('JPXDecode')
+    log.warning("JPX decoder is not implemented. It returns raw unfiltered data.")
+    return binary


### PR DESCRIPTION
don't raise error on unsupported stream filters, return raw unfiltered data instead