### PR TITLE
Fix EOL detection at end of file without a trailing newline

### DIFF
--- a/pdfreader/parsers/base.py
+++ b/pdfreader/parsers/base.py
@@ -88,7 +88,7 @@ class BasicTypesParser(object):
 
     @property
     def is_eol(self):
-        return self.current is None or self.current in EOL
+        return self.is_eof or self.current in EOL
 
     @property
     def is_whitespace(self):

--- a/pdfreader/parsers/base.py
+++ b/pdfreader/parsers/base.py
@@ -73,7 +73,7 @@ class BasicTypesParser(object):
 
     def eol(self):
         """ EOL is either CR or LF or the both """
-        if self.current not in EOL:
+        if not self.is_eol:
             self.on_parser_error("EOL expected")
         self.maybe_eol()
 
@@ -88,7 +88,7 @@ class BasicTypesParser(object):
 
     @property
     def is_eol(self):
-        return self.current is not None and self.current in EOL
+        return self.current is None or self.current in EOL
 
     @property
     def is_whitespace(self):


### PR DESCRIPTION
I've a PDF with a '%%EOF' comment that ends without a newline character. This caused a TypeError exception in comment() on line 187.
I've fixed this by including EOF (None) as a valid EOL marker.

If you accept this PR it would be great if you can make a new release also, so I can convert back to my normal workflow :)
